### PR TITLE
Expose actuator endpoints and update security config

### DIFF
--- a/src/main/java/com/example/enotes/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/enotes/config/security/SecurityConfig.java
@@ -54,7 +54,8 @@ public class SecurityConfig {
         http.csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(req ->
                         req.requestMatchers("/api/v1/home/**", "/api/v1/auth/**", "/swagger-ui/**",
-                                        "/v3/api-docs/**", "/enotes-docs/**", "/enotes-api-docs/**")
+                                        "/v3/api-docs/**", "/enotes-docs/**", "/enotes-api-docs/**",
+                                        "/actuator/**")
                                 .permitAll()
                                 .anyRequest()
                                 .authenticated())

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,9 @@ springdoc.swagger-ui.tags-sorter=alpha
 springdoc.swagger-ui.path=/enotes-docs
 springdoc.api-docs.path=/enotes-api-docs
 
+management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.exclude=beans,logger
+
 #
 #spring.datasource.url=jdbc:mysql://localhost:3306/enotes
 #spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
Added '/actuator/**' to permitted paths in SecurityConfig to allow unauthenticated access to actuator endpoints. Updated application.properties to expose all management endpoints except 'beans' and 'logger'.