### PR TITLE
Add caching support for category APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
 

--- a/src/main/java/com/example/enotes/EnotesApplication.java
+++ b/src/main/java/com/example/enotes/EnotesApplication.java
@@ -2,12 +2,14 @@ package com.example.enotes;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing(auditorAwareRef = "auditAware")
 @EnableScheduling
+@EnableCaching
 public class EnotesApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/enotes/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/enotes/config/security/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(req ->
                         req.requestMatchers("/api/v1/home/**", "/api/v1/auth/**", "/swagger-ui/**",
                                         "/v3/api-docs/**", "/enotes-docs/**", "/enotes-api-docs/**",
-                                        "/actuator/**")
+                                        "/actuator/**", "/api/v1/cache/**")
                                 .permitAll()
                                 .anyRequest()
                                 .authenticated())

--- a/src/main/java/com/example/enotes/controller/CacheController.java
+++ b/src/main/java/com/example/enotes/controller/CacheController.java
@@ -1,0 +1,40 @@
+package com.example.enotes.controller;
+
+import com.example.enotes.endpoint.CacheEndpoint;
+import com.example.enotes.service.CacheManagerService;
+import com.example.enotes.util.CommonUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collection;
+
+@RestController
+public class CacheController implements CacheEndpoint {
+
+    @Autowired
+    private CacheManagerService cacheManagerService;
+
+    @Override
+    public ResponseEntity<?> getAllCache() {
+        Collection<String> cache = cacheManagerService.getCache();
+
+        return CommonUtil.createBuildResponse(cache, HttpStatus.OK);
+    }
+
+    @Override
+    public ResponseEntity<?> getCache(String cache_name) {
+        Cache cacheName = cacheManagerService.getCacheName(cache_name);
+
+        return CommonUtil.createBuildResponse(cacheName, HttpStatus.OK);
+    }
+
+    @Override
+    public ResponseEntity<?> removeAllCache() {
+        cacheManagerService.removeAllCache();
+
+        return CommonUtil.createBuildResponseMessage("Removed all caches", HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/enotes/controller/CategoryController.java
+++ b/src/main/java/com/example/enotes/controller/CategoryController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.example.enotes.endpoint.CategoryEndpoint;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.CollectionUtils;

--- a/src/main/java/com/example/enotes/endpoint/CacheEndpoint.java
+++ b/src/main/java/com/example/enotes/endpoint/CacheEndpoint.java
@@ -1,0 +1,22 @@
+package com.example.enotes.endpoint;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Caching", description = "Caching related API's")
+@RequestMapping("/api/v1/cache")
+public interface CacheEndpoint {
+
+    @GetMapping("/")
+    ResponseEntity<?> getAllCache();
+
+    @GetMapping("/{cache_name}")
+    ResponseEntity<?> getCache(@PathVariable String cache_name);
+
+    @DeleteMapping("/")
+    ResponseEntity<?> removeAllCache();
+}

--- a/src/main/java/com/example/enotes/service/CacheManagerService.java
+++ b/src/main/java/com/example/enotes/service/CacheManagerService.java
@@ -1,0 +1,16 @@
+package com.example.enotes.service;
+
+import org.springframework.cache.Cache;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface CacheManagerService {
+    Collection<String> getCache();
+
+    Cache getCacheName(String cacheName);
+
+    void removeAllCache();
+
+    void removeCacheByName(List<String> cacheNames);
+}

--- a/src/main/java/com/example/enotes/service/impl/CacheManagerServiceImpl.java
+++ b/src/main/java/com/example/enotes/service/impl/CacheManagerServiceImpl.java
@@ -1,0 +1,61 @@
+package com.example.enotes.service.impl;
+
+import com.example.enotes.service.CacheManagerService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.List;
+
+@Slf4j
+@Service
+public class CacheManagerServiceImpl implements CacheManagerService {
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Override
+    public Collection<String> getCache() {
+        Collection<String> cacheNames = cacheManager.getCacheNames();
+
+        for (String cacheName:cacheNames) {
+            Cache cache = cacheManager.getCache(cacheName);
+
+            log.info("Cache name = {}", cache);
+        }
+        return cacheNames;
+    }
+
+    @Override
+    public Cache getCacheName(String cacheName) {
+
+        Cache cache = cacheManager.getCache(cacheName);
+        log.info("Cache name = {}", cache);
+
+        return cache;
+    }
+
+    @Override
+    public void removeAllCache() {
+        Collection<String> cacheNames = cacheManager.getCacheNames();
+
+        for (String cacheName:cacheNames) {
+            Cache cache = cacheManager.getCache(cacheName);
+            log.info("Cache name = {}", cache);
+            cache.clear();
+        }
+    }
+
+    @Override
+    public void removeCacheByName(List<String> cacheNames) {
+        for (String cacheName : cacheNames) {
+            Cache cache = cacheManager.getCache(cacheName);
+            log.info("Cache name = {}", cache);
+
+            cache.clear();
+        }
+    }
+}

--- a/src/main/java/com/example/enotes/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/example/enotes/service/impl/CategoryServiceImpl.java
@@ -1,10 +1,14 @@
 package com.example.enotes.service.impl;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import com.example.enotes.service.CacheManagerService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 
@@ -31,6 +35,9 @@ public class CategoryServiceImpl implements CategoryService {
 
 	@Autowired
 	private Validation validation;
+
+    @Autowired
+    private CacheManagerService cacheManagerService;
 
 	@Override
 	public Boolean saveCategory(CategoryDto categoryDto) {
@@ -80,7 +87,8 @@ public class CategoryServiceImpl implements CategoryService {
 	}
 
 	@Override
-	public List<CategoryDto> getAllCategory() {
+    @Cacheable("allCategory")
+    public List<CategoryDto> getAllCategory() {
 		List<Category> categories = categoryRepo.findByIsDeletedFalse();
 
 		List<CategoryDto> categoryDtoList = categories.stream().map(cat -> mapper.map(cat, CategoryDto.class)).toList();
@@ -89,7 +97,8 @@ public class CategoryServiceImpl implements CategoryService {
 	}
 
 	@Override
-	public List<CategoryResponse> getActiveCategory() {
+    @Cacheable("activeCategory")
+    public List<CategoryResponse> getActiveCategory() {
 
 		List<Category> categories = categoryRepo.findByIsActiveTrueAndIsDeletedFalse();
 		List<CategoryResponse> categoryList = categories.stream().map(cat -> mapper.map(cat, CategoryResponse.class))
@@ -99,6 +108,7 @@ public class CategoryServiceImpl implements CategoryService {
 	}
 
 	@Override
+    @Cacheable(value = "getCategoryById", key = "#id")
 	public CategoryDto getCategoryById(Integer id) throws Exception {
 
 		Category category = categoryRepo.findByIdAndIsDeletedFalse(id)
@@ -117,6 +127,7 @@ public class CategoryServiceImpl implements CategoryService {
 	}
 
 	@Override
+    @CacheEvict(value = "getCategoryById", key = "#id")
 	public Boolean deleteCategory(Integer id) {
 
 		Optional<Category> findByCategory = categoryRepo.findById(id);
@@ -125,6 +136,9 @@ public class CategoryServiceImpl implements CategoryService {
 			Category category = findByCategory.get();
 			category.setIsDeleted(true);
 			categoryRepo.save(category);
+
+            // Remove from cache
+            cacheManagerService.removeCacheByName(Arrays.asList("allCategory", "activeCategory"));
 
 			return true;
 		}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,6 +11,9 @@ springdoc.api-docs.path=/enotes-api-docs
 management.endpoints.web.exposure.include=*
 management.endpoints.web.exposure.exclude=beans,logger
 
+#spring.jpa.properties.hibernate.show-sql=true
+#spring.jpa.properties.hibernate.format_sql=true
+
 #
 #spring.datasource.url=jdbc:mysql://localhost:3306/enotes
 #spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
Integrated Spring Boot caching by adding spring-boot-starter-cache, enabling caching in the application, and implementing cacheable and cache eviction annotations in CategoryServiceImpl. Added CacheManagerService and related controller/endpoint for cache management, updated security config to allow cache endpoints, and made minor property file changes for cache configuration.